### PR TITLE
Expose services for ROS2 Package

### DIFF
--- a/netft_utils/CMakeLists.txt
+++ b/netft_utils/CMakeLists.txt
@@ -20,8 +20,10 @@ geometry_msgs
 pluginlib
 tf2
 tf2_ros
+tf2_geometry_msgs
 netft_interfaces
 )
+
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
 find_package(${Dependency} REQUIRED)
 endforeach()
@@ -37,11 +39,17 @@ add_library(netft_rdt_driver SHARED
 )
 target_compile_features(netft_rdt_driver PUBLIC cxx_std_17)
 target_include_directories(netft_rdt_driver
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+PUBLIC
+$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+$<INSTALL_INTERFACE:include>)
 ament_target_dependencies(netft_rdt_driver ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_link_libraries(netft_rdt_driver ${Boost_LIBRARIES})
+
+add_library(lpfilter SHARED src/lpfilter.cpp)
+ament_target_dependencies(lpfilter
+  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+)
+target_link_libraries(lpfilter ${Boost_LIBRARIES})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -53,6 +61,12 @@ target_include_directories(netft_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(netft_node netft_rdt_driver)
+
+add_executable(netft_utils src/netft_utils.cpp)
+ament_target_dependencies(netft_utils PUBLIC 
+  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+)
+target_link_libraries(netft_utils PUBLIC lpfilter)
 
 # Library for bringup with ros2_controls hardware_interface
 add_library(
@@ -88,6 +102,11 @@ install(TARGETS netft_hardware_interface
 install(
     TARGETS netft_node
     DESTINATION lib/${PROJECT_NAME}
+)
+
+install (
+  TARGETS netft_utils
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 install(TARGETS netft_rdt_driver

--- a/netft_utils/README.md
+++ b/netft_utils/README.md
@@ -10,6 +10,11 @@ To launch the direct node, run the following with the correct IP address
 ros2 run netft_utils netft_node --address WWW.XXX.YYY.ZZZ
 ```
 
+To launch the utility node that exposes services, run the following:
+```bash
+ros2 run netft_utils netft_utils
+```
+
 To run an example launch for `ros2_control` run the following with option namespace
 ```sh
 ros2 launch netft_utils netft.launch.py node_namespace:="test_ns/"

--- a/netft_utils/include/lpfilter.h
+++ b/netft_utils/include/lpfilter.h
@@ -10,8 +10,9 @@ class LPFilter
 public:
   LPFilter(double deltaT, double cutoffFrequency, int numElements);
   bool update(std::vector<double> input, std::vector<double>& output);
-
+  
 private:
+  rclcpp::Logger logger = rclcpp::get_logger("LPFilter");
   bool initialized;
   int noElements;
   std::vector<double> in1, in2, out1, out2;

--- a/netft_utils/include/lpfilter.h
+++ b/netft_utils/include/lpfilter.h
@@ -5,6 +5,15 @@
 #include <rclcpp/rclcpp.hpp>
 #include <math.h>
 
+/**
+ * @brief Implements a multi-element low-pass filter.
+ *
+ * The LPFilter class applies a configurable low-pass filter to input vectors, supporting multiple elements in parallel. It maintains internal state for each element and allows repeated filtering of sequential data.
+ *
+ * @param deltaT Sampling interval in seconds.
+ * @param cutoffFrequency Cutoff frequency of the filter in Hz.
+ * @param numElements Number of elements to filter in each input vector.
+ */
 class LPFilter
 {
 public:

--- a/netft_utils/include/netft_utils.h
+++ b/netft_utils/include/netft_utils.h
@@ -18,13 +18,20 @@
 #include <lpfilter.h>
 #include <math.h>
 
-/**
- * This program takes force/torque data and applies transforms to usable data
+/****
+ * @brief ROS2 node for processing NetFT force/torque sensor data with transformations, bias correction, filtering, and safety monitoring.
+ *
+ * The NetftUtils class subscribes to raw force/torque data, applies coordinate frame transformations, bias and gravity compensation, low-pass filtering, and thresholding. It monitors force/torque limits and publishes processed data and control messages. The class provides ROS services for configuring bias, gravity compensation, thresholds, filtering, and force/torque limits.
  */
 
 namespace netft_utils
 {
 
+  /**
+   * @brief ROS2 node for processing NetFT force/torque sensor data with filtering, bias correction, gravity compensation, and safety monitoring.
+   *
+   * The NetftUtils class subscribes to raw force/torque data, applies coordinate transformations, bias and gravity compensation, low-pass filtering, and thresholding. It monitors force/torque limits and publishes processed data and safety control messages. The class provides ROS services for configuring bias, gravity compensation, filtering, thresholds, and force/torque limits.
+   */
   class NetftUtils : public rclcpp::Node
   {
   public:

--- a/netft_utils/include/netft_utils.h
+++ b/netft_utils/include/netft_utils.h
@@ -6,6 +6,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2/transform_datatypes.h>
 #include <tf2/convert.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
 #include <netft_interfaces/srv/set_bias.hpp>
 #include <netft_interfaces/srv/set_max.hpp>
@@ -24,7 +25,7 @@
 namespace netft_utils
 {
 
-  class NetftUtils : rclcpp::Node
+  class NetftUtils : public rclcpp::Node
   {
   public:
     NetftUtils();

--- a/netft_utils/src/lpfilter.cpp
+++ b/netft_utils/src/lpfilter.cpp
@@ -15,6 +15,15 @@ Author: Alex von Sternberg
 
 #include <lpfilter.h>
 
+/**
+ * @brief Constructs a second-order low-pass digital filter with specified parameters.
+ *
+ * Initializes filter coefficients and internal state for a multi-element low-pass filter using the bilinear transform. Validates input parameters and prepares the filter for processing input vectors of the specified size.
+ *
+ * @param deltaT Sampling interval in seconds; must be greater than zero.
+ * @param cutoffFrequency Cutoff frequency in Hz; must be greater than zero.
+ * @param numElements Number of parallel filter elements; must be positive.
+ */
 LPFilter::LPFilter(double deltaT, double cutoffFrequency, int numElements):
   initialized(false),
   noElements(0),
@@ -63,6 +72,17 @@ LPFilter::LPFilter(double deltaT, double cutoffFrequency, int numElements):
   }
 }
   
+/**
+ * @brief Applies the low-pass filter to the input vector and updates the output vector.
+ *
+ * Processes each element of the input vector using the filter's coefficients and internal state,
+ * updating the output vector with the filtered results. Returns false if the filter is not initialized
+ * or if the input/output vector sizes do not match the expected dimensions.
+ *
+ * @param input Vector of input values to be filtered.
+ * @param output Vector to store the filtered output values; must be pre-sized appropriately.
+ * @return true if filtering was successful; false if initialization or size checks fail.
+ */
 bool LPFilter::update(std::vector<double> input, std::vector<double>& output)
 {
   if(!initialized)

--- a/netft_utils/src/lpfilter.cpp
+++ b/netft_utils/src/lpfilter.cpp
@@ -28,7 +28,7 @@ LPFilter::LPFilter(double deltaT, double cutoffFrequency, int numElements):
   initialized = true;
   if(numElements<=0)
   {
-    RCLCPP_ERROR_STREAM("LPFilter was passed invalid number of elements. Not filtering.");
+    RCLCPP_ERROR_STREAM(logger, "LPFilter was passed invalid number of elements. Not filtering.");
     initialized = false;
   }
   else
@@ -37,12 +37,12 @@ LPFilter::LPFilter(double deltaT, double cutoffFrequency, int numElements):
   }
   if(deltaT<=0)
   {
-    RCLCPP_ERROR_STREAM("LPFilter was passed invalid deltaT. Not Filtering.");
+    RCLCPP_ERROR_STREAM(logger, "LPFilter was passed invalid deltaT. Not Filtering.");
     initialized = false;
   }
   if(cutoffFrequency <=0)
   {
-    RCLCPP_ERROR_STREAM("LPFilter was passed invalid cuttoffFrequency. Not Filtering.");
+    RCLCPP_ERROR_STREAM(logger, "LPFilter was passed invalid cuttoffFrequency. Not Filtering.");
     initialized = false;
   }
   else
@@ -59,7 +59,7 @@ LPFilter::LPFilter(double deltaT, double cutoffFrequency, int numElements):
     in2.resize(noElements);
     out1.resize(noElements);
     out2.resize(noElements);
-    RCLCPP_INFO_STREAM("cutoffFrequency: " << cutoffFrequency << ". omega_a: " << omega_a << ". den: " << den << ". a0: " << a0 << ". a1: " << a1 << ". a2: " << a2 << ". b1: " << b1 << ". b2: " << b2);
+    // RCLCPP_INFO_STREAM("cutoffFrequency: " << cutoffFrequency << ". omega_a: " << omega_a << ". den: " << den << ". a0: " << a0 << ". a1: " << a1 << ". a2: " << a2 << ". b1: " << b1 << ". b2: " << b2);
   }
 }
   
@@ -67,12 +67,12 @@ bool LPFilter::update(std::vector<double> input, std::vector<double>& output)
 {
   if(!initialized)
   {
-    RCLCPP_ERROR_STREAM("LPFilter was not initialized correctly. Not filtering data.");
+    RCLCPP_ERROR_STREAM(logger, "LPFilter was not initialized correctly. Not filtering data.");
     return false;
   }
   if(input.size() != in1.size() || output.size() != out1.size())
   {
-    RCLCPP_ERROR_STREAM("LPFilter incorrect input or output size");
+    RCLCPP_ERROR_STREAM(logger, "LPFilter incorrect input or output size");
     return false;
   }
   for(int i=0; i<noElements; i++)

--- a/netft_utils/src/netft_utils.cpp
+++ b/netft_utils/src/netft_utils.cpp
@@ -68,7 +68,9 @@ namespace netft_utils
     listener = new tf2_ros::TransformListener(bufferCore);
 
     //Subscribe to the NetFT topic.
-    raw_data_sub = create_subscription<geometry_msgs::msg::WrenchStamped>("netft_data",100, &NetftUtils::netftCallback);
+    raw_data_sub = create_subscription<geometry_msgs::msg::WrenchStamped>(
+    "netft_data", 100,
+    [this](const geometry_msgs::msg::WrenchStamped::SharedPtr msg) { this->netftCallback(msg); });
 
     //Publish on the /netft_transformed_data topic. Queue up to 100000 data points
     netft_raw_world_data_pub = create_publisher<geometry_msgs::msg::WrenchStamped>("raw_world", 100000);
@@ -76,15 +78,60 @@ namespace netft_utils
     netft_tool_data_pub = create_publisher<geometry_msgs::msg::WrenchStamped>("transformed_tool", 100000);
     netft_cancel_pub = create_publisher<netft_interfaces::msg::Cancel>("cancel", 100000);
 
-    //Advertise bias and threshold services
-    bias_service = create_service<netft_interfaces::srv::SetBias>("bias", &NetftUtils::fixedOrientationBias);
-    gravity_comp_service = create_service<netft_interfaces::srv::SetBias>("gravity_comp", &NetftUtils::compensateForGravity);
-    set_max_service = create_service<netft_interfaces::srv::SetMax>("set_max_values", &NetftUtils::setMax);
-    threshold_service = create_service<netft_interfaces::srv::SetThreshold>("set_threshold", &NetftUtils::setThreshold);
-    weight_bias_service = create_service<netft_interfaces::srv::SetBias>("set_weight_bias", &NetftUtils::setWeightBias);
-    get_weight_service = create_service<netft_interfaces::srv::GetDouble>("get_weight", &NetftUtils::getWeight);
-    filter_service = create_service<netft_interfaces::srv::SetFilter>("filter", &NetftUtils::setFilter);
-  }
+   //Advertise bias and threshold services
+  bias_service = create_service<netft_interfaces::srv::SetBias>(
+    "bias", [this](
+              const std::shared_ptr<netft_interfaces::srv::SetBias::Request> request,
+              std::shared_ptr<netft_interfaces::srv::SetBias::Response> response) {
+      this->fixedOrientationBias(*request, *response);
+    });
+
+  gravity_comp_service = create_service<netft_interfaces::srv::SetBias>(
+    "gravity_comp", [this](
+                      const std::shared_ptr<netft_interfaces::srv::SetBias::Request> request,
+                      std::shared_ptr<netft_interfaces::srv::SetBias::Response> response) {
+      this->compensateForGravity(*request, *response);
+    });
+
+  set_max_service = create_service<netft_interfaces::srv::SetMax>(
+    "set_max_"
+    "values",
+    [this](
+      const std::shared_ptr<netft_interfaces::srv::SetMax::Request> request,
+      std::shared_ptr<netft_interfaces::srv::SetMax::Response> response) {
+      this->setMax(*request, *response);
+    });
+
+  threshold_service = create_service<netft_interfaces::srv::SetThreshold>(
+    "set_threshold", [this](
+                       const std::shared_ptr<netft_interfaces::srv::SetThreshold::Request> request,
+                       std::shared_ptr<netft_interfaces::srv::SetThreshold::Response> response) {
+      this->setThreshold(*request, *response);
+    });
+
+  weight_bias_service = create_service<netft_interfaces::srv::SetBias>(
+    "set_weight_"
+    "bias",
+    [this](
+      const std::shared_ptr<netft_interfaces::srv::SetBias::Request> request,
+      std::shared_ptr<netft_interfaces::srv::SetBias::Response> response) {
+      this->setWeightBias(*request, *response);
+    });
+
+  get_weight_service = create_service<netft_interfaces::srv::GetDouble>(
+    "get_weight", [this](
+                    const std::shared_ptr<netft_interfaces::srv::GetDouble::Request> request,
+                    std::shared_ptr<netft_interfaces::srv::GetDouble::Response> response) {
+      this->getWeight(*request, *response);
+    });
+
+  filter_service = create_service<netft_interfaces::srv::SetFilter>(
+    "filter", [this](
+                const std::shared_ptr<netft_interfaces::srv::SetFilter::Request> request,
+                std::shared_ptr<netft_interfaces::srv::SetFilter::Response> response) {
+      this->setFilter(*request, *response);
+    });
+}
 
   void NetftUtils::setUserInput(std::string world, std::string ft, double force, double torque)
   {
@@ -136,7 +183,7 @@ namespace netft_utils
     netft_tool_data_pub->publish( tf_data_tool );
     netft_cancel_pub->publish( cancel_msg );
 
-    rclcpp::spin_some(this->make_shared());
+    rclcpp::spin_some(this->shared_from_this());
   }
 
   void NetftUtils::copyWrench(geometry_msgs::msg::WrenchStamped &in, geometry_msgs::msg::WrenchStamped &out, geometry_msgs::msg::WrenchStamped &bias)
@@ -442,61 +489,63 @@ namespace netft_utils
       cancel_count = MAX_CANCEL;
       cancel_wait = MAX_WAIT;
     }
-  }        
+  }               
+}
 
-  
-  int main(int argc, char **argv)
+int main(int argc, char **argv)
+{
+  // Initialize the ros netft_utils_node
+  rclcpp::init(argc, argv);
+
+  // Instantiate utils class
+  // NetftUtils utils;
+  auto utils = std::make_shared<netft_utils::NetftUtils>();
+  // Initialize utils
+  utils->initialize();
+
+  // Set up a multi-threaded executor
+  using rclcpp::executors::MultiThreadedExecutor;
+  MultiThreadedExecutor exec;
+  exec.add_node(utils);
+  exec.spin();
+
+
+  // Set up user input
+  std::string world_frame;
+  std::string ft_frame;
+  double forceMaxU = 0.0;
+  double torqueMaxU = 0.0;
+  if(argc<3)
   {
-    // Initialize the ros netft_utils_node
-    rclcpp::init(argc, argv);
-
-    // Instantiate utils class
-    NetftUtils utils;
-    using rclcpp::executors::MultiThreadedExecutor;
-    MultiThreadedExecutor exec;
-    exec.spin();
-
-    // Initialize utils
-    utils.initialize();
-
-    // Set up user input
-    std::string world_frame;
-    std::string ft_frame;
-    double forceMaxU = 0.0;
-    double torqueMaxU = 0.0;
-    if(argc<3)
-    {
-      RCLCPP_FATAL(utils.getLog(), "You must pass in at least the world and ft frame as command line arguments. Argument options are [world frame, ft frame, max force, max torque]");
-      return 1;
-    }
-    else if(argc>=6)
-    {
-      RCLCPP_FATAL(utils.getLog(), "Too many arguments for netft_utils");
-    }
-    else
-    {
-      world_frame = argv[1];
-      ft_frame = argv[2];
-      if(argc>=4)
-        forceMaxU = atof(argv[3]);
-      if(5==argc)
-        torqueMaxU = atof(argv[4]);
-    }
-    utils.setUserInput(world_frame, ft_frame, forceMaxU, torqueMaxU);
-
-    // Main ros loop
-    rclcpp::Rate loop_rate(500);
-    //ros::Time last;
-    while(rclcpp::ok())
-    {
-      utils.update();
-      loop_rate.sleep();
-      //ros::Time curr = ros::Time::now();
-      //ROS_INFO_STREAM("Loop time: " <<  curr.toSec()-last.toSec());
-      //last = curr;
-    }
-
-    return 0;
+    RCLCPP_FATAL(utils->getLog(), "You must pass in at least the world and ft frame as command line arguments. Argument options are [world frame, ft frame, max force, max torque]");
+    return 1;
   }
-       
+  else if(argc>=6)
+  {
+    RCLCPP_FATAL(utils->getLog(), "Too many arguments for netft_utils");
+  }
+  else
+  {
+    world_frame = argv[1];
+    ft_frame = argv[2];
+    if(argc>=4)
+      forceMaxU = atof(argv[3]);
+    if(5==argc)
+      torqueMaxU = atof(argv[4]);
+  }
+  utils->setUserInput(world_frame, ft_frame, forceMaxU, torqueMaxU);
+
+  // Main ros loop
+  rclcpp::Rate loop_rate(500);
+  //ros::Time last;
+  while(rclcpp::ok())
+  {
+    utils->update();
+    loop_rate.sleep();
+    //ros::Time curr = ros::Time::now();
+    //ROS_INFO_STREAM("Loop time: " <<  curr.toSec()-last.toSec());
+    //last = curr;
+  }
+
+  return 0;
 }

--- a/netft_utils/src/netft_utils.cpp
+++ b/netft_utils/src/netft_utils.cpp
@@ -1,4 +1,3 @@
-
 /*
 Copyright (c) 2016, Los Alamos National Security, LLC
 All rights reserved.
@@ -49,7 +48,12 @@ namespace netft_utils
     return this->get_logger();
   }
 
-  void NetftUtils::initialize()
+  /**
+ * @brief Initializes the NetftUtils node, setting up publishers, subscribers, and services.
+ *
+ * Configures internal state, subscribes to raw NetFT wrench data, advertises publishers for processed wrench and cancel messages, and creates services for biasing, gravity compensation, thresholding, filtering, and related operations. Also initializes the TF2 transform listener for frame transformations.
+ */
+void NetftUtils::initialize()
   {
     //lp = new LPFilter(0.002,200,6);
 
@@ -133,6 +137,14 @@ namespace netft_utils
     });
 }
 
+  /**
+   * @brief Sets the world and force-torque sensor frame names and optionally updates user-defined force and torque limits.
+   *
+   * @param world Name of the world reference frame.
+   * @param ft Name of the force-torque sensor frame.
+   * @param force Maximum allowable force; updates the user-defined limit if nonzero.
+   * @param torque Maximum allowable torque; updates the user-defined limit if nonzero.
+   */
   void NetftUtils::setUserInput(std::string world, std::string ft, double force, double torque)
   {
     world_frame = world;
@@ -147,6 +159,11 @@ namespace netft_utils
     }
   }
 
+  /**
+   * @brief Updates the internal state, applies filtering and transforms, checks force/torque limits, and publishes processed wrench data.
+   *
+   * If a new filter is requested, replaces the existing filter with updated parameters. Looks up and updates the transform between the force-torque sensor and world frames. Resets the translation component of the transform. Checks if force or torque limits are exceeded and updates the cancel message accordingly. Publishes the latest raw and transformed wrench data and cancel status. Processes any pending ROS callbacks.
+   */
   void NetftUtils::update()
   {
     // Check for a filter
@@ -186,6 +203,15 @@ namespace netft_utils
     rclcpp::spin_some(this->shared_from_this());
   }
 
+  /**
+   * @brief Copies a wrench message, subtracting a bias from each force and torque component.
+   *
+   * The output wrench's header and frame ID are set to match the input. Each force and torque component is computed as the input value minus the corresponding bias value.
+   *
+   * @param in Input wrench message.
+   * @param out Output wrench message with bias subtracted.
+   * @param bias Wrench message representing the bias to subtract.
+   */
   void NetftUtils::copyWrench(geometry_msgs::msg::WrenchStamped &in, geometry_msgs::msg::WrenchStamped &out, geometry_msgs::msg::WrenchStamped &bias)
   {
     out.header.stamp = in.header.stamp;
@@ -445,6 +471,11 @@ namespace netft_utils
     return true;    
   }
 
+  /**
+   * @brief Monitors force and torque magnitudes and manages cancel signaling if limits are exceeded.
+   *
+   * Computes the magnitudes of force and torque in the tool frame and compares them to configured maximums, which depend on whether biasing is active. If limits are exceeded, sets a cancel message and decrements a counter to limit repeated cancel signals. Implements a wait period after repeated cancels before allowing new cancels. Resets counters when force and torque return to safe levels.
+   */
   void NetftUtils::checkMaxForce()
   {
     double fMag = pow((pow(tf_data_tool.wrench.force.x, 2.0) + pow(tf_data_tool.wrench.force.y, 2.0) + pow(tf_data_tool.wrench.force.z, 2.0)), 0.5);
@@ -492,6 +523,15 @@ namespace netft_utils
   }               
 }
 
+/**
+ * @brief Entry point for the netft_utils ROS 2 node.
+ *
+ * Initializes ROS 2, creates and configures the NetftUtils node, processes command-line arguments for frame names and optional force/torque limits, and enters the main loop to process wrench data and update the node at a fixed rate.
+ *
+ * @param argc Number of command-line arguments.
+ * @param argv Array of command-line argument strings.
+ * @return int Exit code (0 for success, nonzero for failure).
+ */
 int main(int argc, char **argv)
 {
   // Initialize the ros netft_utils_node

--- a/netft_utils/src/netft_utils.cpp
+++ b/netft_utils/src/netft_utils.cpp
@@ -16,73 +16,73 @@ Authors: Alex von Sternberg, Andy Zelenak
 #include <netft_utils.h>
 namespace netft_utils
 {
-  NetftUtils::NetftUtils() : Node("netft_utils"),
-    isFilterOn(false),
-    deltaTFilter(0.0),
-    cutoffFrequency(0.0),
-    newFilter(false),
-    isBiased(false),
-    isGravityBiased(false),
-    isNewBias(false),
-    isNewGravityBias(false),
-    cancel_count(MAX_CANCEL),
-    cancel_wait(MAX_WAIT),
-    forceMaxB(10.0),
-    torqueMaxB(0.8),
-    forceMaxU(50.0),
-    torqueMaxU(5.0),
-    payloadWeight(0.),
-    payloadLeverArm(0.)
-  {
+NetftUtils::NetftUtils()
+: Node("netft_utils"),
+  isFilterOn(false),
+  deltaTFilter(0.0),
+  cutoffFrequency(0.0),
+  newFilter(false),
+  isBiased(false),
+  isGravityBiased(false),
+  isNewBias(false),
+  isNewGravityBias(false),
+  cancel_count(MAX_CANCEL),
+  cancel_wait(MAX_WAIT),
+  forceMaxB(10.0),
+  torqueMaxB(0.8),
+  forceMaxU(50.0),
+  torqueMaxU(5.0),
+  payloadWeight(0.),
+  payloadLeverArm(0.)
+{
+}
 
-  }
+NetftUtils::~NetftUtils()
+{
+  delete listener;
+  delete lp;
+}
 
-  NetftUtils::~NetftUtils()
-  {
-    delete listener;
-    delete lp;
-  }
+rclcpp::Logger NetftUtils::getLog() { return this->get_logger(); }
 
-  rclcpp::Logger NetftUtils::getLog()
-  {
-    return this->get_logger();
-  }
-
-  /**
+/**
  * @brief Initializes the NetftUtils node, setting up publishers, subscribers, and services.
  *
  * Configures internal state, subscribes to raw NetFT wrench data, advertises publishers for processed wrench and cancel messages, and creates services for biasing, gravity compensation, thresholding, filtering, and related operations. Also initializes the TF2 transform listener for frame transformations.
  */
 void NetftUtils::initialize()
-  {
-    //lp = new LPFilter(0.002,200,6);
+{
+  //lp = new LPFilter(0.002,200,6);
 
-    //Zero out the zero wrench
-    zero_wrench.wrench.force.x = 0.0;
-    zero_wrench.wrench.force.y = 0.0;
-    zero_wrench.wrench.force.z = 0.0;
-    zero_wrench.wrench.torque.x = 0.0;
-    zero_wrench.wrench.torque.y = 0.0;
-    zero_wrench.wrench.torque.z = 0.0;
+  //Zero out the zero wrench
+  zero_wrench.wrench.force.x = 0.0;
+  zero_wrench.wrench.force.y = 0.0;
+  zero_wrench.wrench.force.z = 0.0;
+  zero_wrench.wrench.torque.x = 0.0;
+  zero_wrench.wrench.torque.y = 0.0;
+  zero_wrench.wrench.torque.z = 0.0;
 
-    //Initialize cancel message
-    cancel_msg.cancel = false;
+  //Initialize cancel message
+  cancel_msg.cancel = false;
 
-    //Listen to the transfomation from the ft sensor to world frame.
-    listener = new tf2_ros::TransformListener(bufferCore);
+  //Listen to the transfomation from the ft sensor to world frame.
+  listener = new tf2_ros::TransformListener(bufferCore);
 
-    //Subscribe to the NetFT topic.
-    raw_data_sub = create_subscription<geometry_msgs::msg::WrenchStamped>(
+  //Subscribe to the NetFT topic.
+  raw_data_sub = create_subscription<geometry_msgs::msg::WrenchStamped>(
     "netft_data", 100,
     [this](const geometry_msgs::msg::WrenchStamped::SharedPtr msg) { this->netftCallback(msg); });
 
-    //Publish on the /netft_transformed_data topic. Queue up to 100000 data points
-    netft_raw_world_data_pub = create_publisher<geometry_msgs::msg::WrenchStamped>("raw_world", 100000);
-    netft_world_data_pub = create_publisher<geometry_msgs::msg::WrenchStamped>("transformed_world", 100000);
-    netft_tool_data_pub = create_publisher<geometry_msgs::msg::WrenchStamped>("transformed_tool", 100000);
-    netft_cancel_pub = create_publisher<netft_interfaces::msg::Cancel>("cancel", 100000);
+  //Publish on the /netft_transformed_data topic. Queue up to 100000 data points
+  netft_raw_world_data_pub =
+    create_publisher<geometry_msgs::msg::WrenchStamped>("raw_world", 100000);
+  netft_world_data_pub =
+    create_publisher<geometry_msgs::msg::WrenchStamped>("transformed_world", 100000);
+  netft_tool_data_pub =
+    create_publisher<geometry_msgs::msg::WrenchStamped>("transformed_tool", 100000);
+  netft_cancel_pub = create_publisher<netft_interfaces::msg::Cancel>("cancel", 100000);
 
-   //Advertise bias and threshold services
+  //Advertise bias and threshold services
   bias_service = create_service<netft_interfaces::srv::SetBias>(
     "bias", [this](
               const std::shared_ptr<netft_interfaces::srv::SetBias::Request> request,
@@ -137,7 +137,7 @@ void NetftUtils::initialize()
     });
 }
 
-  /**
+/**
    * @brief Sets the world and force-torque sensor frame names and optionally updates user-defined force and torque limits.
    *
    * @param world Name of the world reference frame.
@@ -145,65 +145,59 @@ void NetftUtils::initialize()
    * @param force Maximum allowable force; updates the user-defined limit if nonzero.
    * @param torque Maximum allowable torque; updates the user-defined limit if nonzero.
    */
-  void NetftUtils::setUserInput(std::string world, std::string ft, double force, double torque)
-  {
-    world_frame = world;
-    ft_frame = ft;
-    if(force != 0.0)
-    {
-      forceMaxU = force;
-    }
-    if(torque != 0.0)
-    {
-      torqueMaxU = torque;
-    }
+void NetftUtils::setUserInput(std::string world, std::string ft, double force, double torque)
+{
+  world_frame = world;
+  ft_frame = ft;
+  if (force != 0.0) {
+    forceMaxU = force;
   }
+  if (torque != 0.0) {
+    torqueMaxU = torque;
+  }
+}
 
-  /**
+/**
    * @brief Updates the internal state, applies filtering and transforms, checks force/torque limits, and publishes processed wrench data.
    *
    * If a new filter is requested, replaces the existing filter with updated parameters. Looks up and updates the transform between the force-torque sensor and world frames. Resets the translation component of the transform. Checks if force or torque limits are exceeded and updates the cancel message accordingly. Publishes the latest raw and transformed wrench data and cancel status. Processes any pending ROS callbacks.
    */
-  void NetftUtils::update()
-  {
-    // Check for a filter
-    if(newFilter)
-    {
-      delete lp;
-      lp = new LPFilter(deltaTFilter,cutoffFrequency,6);
-      newFilter = false;
-    }
-    // Look up transform from ft to world frame
-    geometry_msgs::msg::TransformStamped tempTransform;
-    tf2::TimePoint time;
+void NetftUtils::update()
+{
+  // Check for a filter
+  if (newFilter) {
+    delete lp;
+    lp = new LPFilter(deltaTFilter, cutoffFrequency, 6);
+    newFilter = false;
+  }
+  // Look up transform from ft to world frame
+  geometry_msgs::msg::TransformStamped tempTransform;
+  tf2::TimePoint time;
 
-    try
-    {
-      tempTransform = bufferCore.lookupTransform(world_frame, ft_frame, time);
-      // listener->waitForTransform(world_frame, ft_frame, ros::Time(0), ros::Duration(1.0));
-      // listener->lookupTransform(world_frame, ft_frame, ros::Time(0), tempTransform);
-    }
-    catch (tf2::TransformException ex)
-    {
-      RCLCPP_ERROR(get_logger(), ex.what());
-    }
-
-    // Set translation to zero before updating value
-    tf2::convert(tempTransform, ft_to_world);
-    ft_to_world.setOrigin(tf2::Vector3(0.0,0.0,0.0));
-
-    checkMaxForce();
-
-    // Publish transformed dat
-    netft_raw_world_data_pub->publish( raw_data_world );
-    netft_world_data_pub->publish( tf_data_world );
-    netft_tool_data_pub->publish( tf_data_tool );
-    netft_cancel_pub->publish( cancel_msg );
-
-    rclcpp::spin_some(this->shared_from_this());
+  try {
+    tempTransform = bufferCore.lookupTransform(world_frame, ft_frame, time);
+    // listener->waitForTransform(world_frame, ft_frame, ros::Time(0), ros::Duration(1.0));
+    // listener->lookupTransform(world_frame, ft_frame, ros::Time(0), tempTransform);
+  } catch (tf2::TransformException ex) {
+    RCLCPP_ERROR(get_logger(), ex.what());
   }
 
-  /**
+  // Set translation to zero before updating value
+  tf2::convert(tempTransform, ft_to_world);
+  ft_to_world.setOrigin(tf2::Vector3(0.0, 0.0, 0.0));
+
+  checkMaxForce();
+
+  // Publish transformed dat
+  netft_raw_world_data_pub->publish(raw_data_world);
+  netft_world_data_pub->publish(tf_data_world);
+  netft_tool_data_pub->publish(tf_data_tool);
+  netft_cancel_pub->publish(cancel_msg);
+
+  rclcpp::spin_some(this->shared_from_this());
+}
+
+/**
    * @brief Copies a wrench message, subtracting a bias from each force and torque component.
    *
    * The output wrench's header and frame ID are set to match the input. Each force and torque component is computed as the input value minus the corresponding bias value.
@@ -212,316 +206,316 @@ void NetftUtils::initialize()
    * @param out Output wrench message with bias subtracted.
    * @param bias Wrench message representing the bias to subtract.
    */
-  void NetftUtils::copyWrench(geometry_msgs::msg::WrenchStamped &in, geometry_msgs::msg::WrenchStamped &out, geometry_msgs::msg::WrenchStamped &bias)
+void NetftUtils::copyWrench(
+  geometry_msgs::msg::WrenchStamped & in, geometry_msgs::msg::WrenchStamped & out,
+  geometry_msgs::msg::WrenchStamped & bias)
+{
+  out.header.stamp = in.header.stamp;
+  out.header.frame_id = in.header.frame_id;
+  out.wrench.force.x = in.wrench.force.x - bias.wrench.force.x;
+  out.wrench.force.y = in.wrench.force.y - bias.wrench.force.y;
+  out.wrench.force.z = in.wrench.force.z - bias.wrench.force.z;
+  out.wrench.torque.x = in.wrench.torque.x - bias.wrench.torque.x;
+  out.wrench.torque.y = in.wrench.torque.y - bias.wrench.torque.y;
+  out.wrench.torque.z = in.wrench.torque.z - bias.wrench.torque.z;
+}
+
+void NetftUtils::applyThreshold(double & value, double thresh)
+{
+  if (value <= thresh && value >= -thresh) {
+    value = 0.0;
+  }
+}
+
+void NetftUtils::transformFrame(
+  geometry_msgs::msg::WrenchStamped in_data, geometry_msgs::msg::WrenchStamped & out_data,
+  char target_frame)
+{
+  tf2::Vector3 tempF;
+  tf2::Vector3 tempT;
+  tempF.setX(in_data.wrench.force.x);
+  tempF.setY(in_data.wrench.force.y);
+  tempF.setZ(in_data.wrench.force.z);
+  tempT.setX(in_data.wrench.torque.x);
+  tempT.setY(in_data.wrench.torque.y);
+  tempT.setZ(in_data.wrench.torque.z);
+  if (target_frame == 'w') {
+    out_data.header.frame_id = world_frame;
+    tempF = ft_to_world * tempF;
+    tempT = ft_to_world * tempT;
+  } else if (target_frame == 't') {
+    out_data.header.frame_id = ft_frame;
+    tempF = ft_to_world.inverse() * tempF;
+    tempT = ft_to_world.inverse() * tempT;
+  }
+  out_data.header.stamp = in_data.header.stamp;
+  out_data.wrench.force.x = tempF.getX();
+  out_data.wrench.force.y = tempF.getY();
+  out_data.wrench.force.z = tempF.getZ();
+  out_data.wrench.torque.x = tempT.getX();
+  out_data.wrench.torque.y = tempT.getY();
+  out_data.wrench.torque.z = tempT.getZ();
+}
+
+// Runs when a new datapoint comes in
+void NetftUtils::netftCallback(const geometry_msgs::msg::WrenchStamped::ConstPtr & data)
+{
+  // Filter data
+  std::vector<double> tempData;
+  tempData.resize(6);
+  tempData.at(0) = -data->wrench.force.x;
+  tempData.at(1) = data->wrench.force.y;
+  tempData.at(2) = data->wrench.force.z;
+  tempData.at(3) = -data->wrench.torque.x;
+  tempData.at(4) = data->wrench.torque.y;
+  tempData.at(5) = data->wrench.torque.z;
+
+  if (isFilterOn && !newFilter) lp->update(tempData, tempData);
+
+  // Copy tool frame data. apply negative to x data to follow right hand rule convention (ft raw data does not)
+  raw_data_tool.header.stamp = data->header.stamp;
+  raw_data_tool.header.frame_id = ft_frame;
+  raw_data_tool.wrench.force.x = tempData.at(0);
+  raw_data_tool.wrench.force.y = tempData.at(1);
+  raw_data_tool.wrench.force.z = tempData.at(2);
+  raw_data_tool.wrench.torque.x = tempData.at(3);
+  raw_data_tool.wrench.torque.y = tempData.at(4);
+  raw_data_tool.wrench.torque.z = tempData.at(5);
+
+  // Copy in new netft data in tool frame and transform to world frame
+  transformFrame(raw_data_tool, raw_data_world, 'w');
+
+  if (isGravityBiased)  // Compensate for gravity. Assumes world Z-axis is up
   {
-    out.header.stamp = in.header.stamp;
-    out.header.frame_id = in.header.frame_id;
-    out.wrench.force.x = in.wrench.force.x - bias.wrench.force.x;
-    out.wrench.force.y = in.wrench.force.y - bias.wrench.force.y;
-    out.wrench.force.z = in.wrench.force.z - bias.wrench.force.z;
-    out.wrench.torque.x = in.wrench.torque.x - bias.wrench.torque.x;
-    out.wrench.torque.y = in.wrench.torque.y - bias.wrench.torque.y;
-    out.wrench.torque.z = in.wrench.torque.z - bias.wrench.torque.z;
+    // Gravity moment = (payloadLeverArm) cross (payload force)  <== all in the sensor frame. Need to convert to world later
+    // Since it's assumed that the CoM of the payload is on the sensor's central axis, this calculation is simplified.
+    double gravMomentX = -payloadLeverArm * tf_data_tool.wrench.force.y;
+    double gravMomentY = payloadLeverArm * tf_data_tool.wrench.force.x;
+
+    // Subtract the gravity torques from the previously-calculated wrench in the tool frame
+    tf_data_tool.wrench.torque.x = tf_data_tool.wrench.torque.x - gravMomentX;
+    tf_data_tool.wrench.torque.y = tf_data_tool.wrench.torque.y - gravMomentY;
+
+    // Convert to world to account for the gravity force. Assumes world-Z is up.
+    //ROS_INFO_STREAM("gravity force in the world Z axis: "<< payloadWeight);
+    transformFrame(tf_data_tool, tf_data_world, 'w');
+    tf_data_world.wrench.force.z = tf_data_world.wrench.force.z - payloadWeight;
+
+    // tf_data_world now accounts for gravity completely. Convert back to the tool frame to make that data available, too
+    transformFrame(tf_data_world, tf_data_tool, 't');
   }
 
-  void NetftUtils::applyThreshold(double &value, double thresh)
+  if (isBiased)  // Apply the bias for a static sensor frame
   {
-    if(value <= thresh && value >= -thresh)
-    {
-      value = 0.0;
-    }
-  }
-
-  void NetftUtils::transformFrame(geometry_msgs::msg::WrenchStamped in_data, geometry_msgs::msg::WrenchStamped &out_data, char target_frame)
+    // Get tool bias in world frame
+    geometry_msgs::msg::WrenchStamped world_bias;
+    transformFrame(bias, world_bias, 'w');
+    // Add bias and apply threshold to get transformed data
+    copyWrench(raw_data_world, tf_data_world, world_bias);
+  } else  // Just pass the data straight through
   {
-    tf2::Vector3 tempF;
-    tf2::Vector3 tempT;
-    tempF.setX(in_data.wrench.force.x);
-    tempF.setY(in_data.wrench.force.y);
-    tempF.setZ(in_data.wrench.force.z);
-    tempT.setX(in_data.wrench.torque.x);
-    tempT.setY(in_data.wrench.torque.y);
-    tempT.setZ(in_data.wrench.torque.z);
-    if(target_frame == 'w')
-    {
-        out_data.header.frame_id = world_frame;
-        tempF = ft_to_world * tempF;
-        tempT = ft_to_world * tempT;
-    }
-    else if(target_frame == 't')
-    {
-        out_data.header.frame_id = ft_frame;
-        tempF = ft_to_world.inverse() * tempF;
-        tempT = ft_to_world.inverse() * tempT;
-    }	
-    out_data.header.stamp = in_data.header.stamp;
-    out_data.wrench.force.x = tempF.getX();
-    out_data.wrench.force.y = tempF.getY();
-    out_data.wrench.force.z = tempF.getZ();
-    out_data.wrench.torque.x = tempT.getX();
-    out_data.wrench.torque.y = tempT.getY();
-    out_data.wrench.torque.z = tempT.getZ();
+    copyWrench(raw_data_world, tf_data_world, zero_wrench);
+    copyWrench(raw_data_tool, tf_data_tool, zero_wrench);
   }
 
-  // Runs when a new datapoint comes in
-  void NetftUtils::netftCallback(const geometry_msgs::msg::WrenchStamped::ConstPtr& data)
-  {
-    // Filter data
-    std::vector<double> tempData;
-    tempData.resize(6);
-    tempData.at(0) = -data->wrench.force.x;
-    tempData.at(1) = data->wrench.force.y;
-    tempData.at(2) = data->wrench.force.z;
-    tempData.at(3) = -data->wrench.torque.x;
-    tempData.at(4) = data->wrench.torque.y;
-    tempData.at(5) = data->wrench.torque.z;
-    
-    if(isFilterOn && !newFilter)
-      lp->update(tempData,tempData);
+  // Apply thresholds
+  applyThreshold(tf_data_world.wrench.force.x, threshold.wrench.force.x);
+  applyThreshold(tf_data_world.wrench.force.y, threshold.wrench.force.y);
+  applyThreshold(tf_data_world.wrench.force.z, threshold.wrench.force.z);
+  applyThreshold(tf_data_world.wrench.torque.x, threshold.wrench.torque.x);
+  applyThreshold(tf_data_world.wrench.torque.y, threshold.wrench.torque.y);
+  applyThreshold(tf_data_world.wrench.torque.z, threshold.wrench.torque.z);
+  applyThreshold(tf_data_tool.wrench.force.x, threshold.wrench.force.x);
+  applyThreshold(tf_data_tool.wrench.force.y, threshold.wrench.force.y);
+  applyThreshold(tf_data_tool.wrench.force.z, threshold.wrench.force.z);
+  applyThreshold(tf_data_tool.wrench.torque.x, threshold.wrench.torque.x);
+  applyThreshold(tf_data_tool.wrench.torque.y, threshold.wrench.torque.y);
+  applyThreshold(tf_data_tool.wrench.torque.z, threshold.wrench.torque.z);
+  //ROS_INFO_STREAM("Callback time: " << tf_data_tool.header.stamp.toSec()-ros::Time::now().toSec());
+}
 
-    // Copy tool frame data. apply negative to x data to follow right hand rule convention (ft raw data does not)
-    raw_data_tool.header.stamp = data->header.stamp;
-    raw_data_tool.header.frame_id = ft_frame;
-    raw_data_tool.wrench.force.x = tempData.at(0);
-    raw_data_tool.wrench.force.y = tempData.at(1);
-    raw_data_tool.wrench.force.z = tempData.at(2);
-    raw_data_tool.wrench.torque.x = tempData.at(3);
-    raw_data_tool.wrench.torque.y = tempData.at(4);
-    raw_data_tool.wrench.torque.z = tempData.at(5);
+// Set the readings from the sensor to zero at this instant and continue to apply the bias on future readings.
+// This doesn't account for gravity.
+// Useful when the sensor's orientation won't change.
+// Run this method when the sensor is stationary to avoid inertial effects.
+// Cannot bias the sensor if gravity compensation has already been applied.
+bool NetftUtils::fixedOrientationBias(
+  netft_interfaces::srv::SetBias::Request & req, netft_interfaces::srv::SetBias::Response & res)
+{
+  if (req.bias) {
+    copyWrench(
+      raw_data_tool, bias,
+      zero_wrench);  // Store the current wrench readings in the 'bias' variable, to be applied hereafter
+    if (req.force >= 0.0001)  // if forceMax was specified and > 0
+      forceMaxB = req.force;
+    if (req.torque >= 0.0001) torqueMaxB = req.torque;  // if torqueMax was specified and > 0
 
-    // Copy in new netft data in tool frame and transform to world frame
-    transformFrame(raw_data_tool, raw_data_world, 'w');
-    
-    if (isGravityBiased) // Compensate for gravity. Assumes world Z-axis is up
-    {
-        // Gravity moment = (payloadLeverArm) cross (payload force)  <== all in the sensor frame. Need to convert to world later
-        // Since it's assumed that the CoM of the payload is on the sensor's central axis, this calculation is simplified.
-        double gravMomentX = -payloadLeverArm*tf_data_tool.wrench.force.y;
-        double gravMomentY = payloadLeverArm*tf_data_tool.wrench.force.x;
-
-        // Subtract the gravity torques from the previously-calculated wrench in the tool frame
-        tf_data_tool.wrench.torque.x = tf_data_tool.wrench.torque.x - gravMomentX;
-        tf_data_tool.wrench.torque.y = tf_data_tool.wrench.torque.y - gravMomentY;
-
-        // Convert to world to account for the gravity force. Assumes world-Z is up.
-        //ROS_INFO_STREAM("gravity force in the world Z axis: "<< payloadWeight);
-        transformFrame(tf_data_tool, tf_data_world, 'w');
-        tf_data_world.wrench.force.z = tf_data_world.wrench.force.z - payloadWeight;
-
-        // tf_data_world now accounts for gravity completely. Convert back to the tool frame to make that data available, too
-        transformFrame(tf_data_world, tf_data_tool, 't');
-    }
-    
-    if (isBiased) // Apply the bias for a static sensor frame
-    {
-      // Get tool bias in world frame
-      geometry_msgs::msg::WrenchStamped world_bias;
-      transformFrame(bias, world_bias, 'w');
-      // Add bias and apply threshold to get transformed data
-      copyWrench(raw_data_world, tf_data_world, world_bias);
-    }
-    else // Just pass the data straight through
-    {
-      copyWrench(raw_data_world, tf_data_world, zero_wrench);
-      copyWrench(raw_data_tool, tf_data_tool, zero_wrench);
-    }
-
-    // Apply thresholds
-    applyThreshold(tf_data_world.wrench.force.x, threshold.wrench.force.x);
-    applyThreshold(tf_data_world.wrench.force.y, threshold.wrench.force.y);
-    applyThreshold(tf_data_world.wrench.force.z, threshold.wrench.force.z);
-    applyThreshold(tf_data_world.wrench.torque.x, threshold.wrench.torque.x);
-    applyThreshold(tf_data_world.wrench.torque.y, threshold.wrench.torque.y);
-    applyThreshold(tf_data_world.wrench.torque.z, threshold.wrench.torque.z);
-    applyThreshold(tf_data_tool.wrench.force.x, threshold.wrench.force.x);
-    applyThreshold(tf_data_tool.wrench.force.y, threshold.wrench.force.y);
-    applyThreshold(tf_data_tool.wrench.force.z, threshold.wrench.force.z);
-    applyThreshold(tf_data_tool.wrench.torque.x, threshold.wrench.torque.x);
-    applyThreshold(tf_data_tool.wrench.torque.y, threshold.wrench.torque.y);
-    applyThreshold(tf_data_tool.wrench.torque.z, threshold.wrench.torque.z);
-    //ROS_INFO_STREAM("Callback time: " << tf_data_tool.header.stamp.toSec()-ros::Time::now().toSec());
+    isNewBias = true;
+    isBiased = true;
+  } else {
+    copyWrench(zero_wrench, bias, zero_wrench);  // Clear the stored bias if the argument was false
   }
 
-  // Set the readings from the sensor to zero at this instant and continue to apply the bias on future readings.
-  // This doesn't account for gravity.
-  // Useful when the sensor's orientation won't change.
-  // Run this method when the sensor is stationary to avoid inertial effects.
-  // Cannot bias the sensor if gravity compensation has already been applied.
-  bool NetftUtils::fixedOrientationBias(netft_interfaces::srv::SetBias::Request &req, netft_interfaces::srv::SetBias::Response &res)
-  {                 
-    if(req.bias)  
-    {           
-      copyWrench(raw_data_tool, bias, zero_wrench); // Store the current wrench readings in the 'bias' variable, to be applied hereafter
-      if(req.force >= 0.0001) // if forceMax was specified and > 0
-        forceMaxB = req.force;
-      if(req.torque >= 0.0001)
-        torqueMaxB = req.torque; // if torqueMax was specified and > 0
+  res.success = true;
 
-      isNewBias = true;
-      isBiased = true;
-    }               
-    else            
-    {               
-      copyWrench(zero_wrench, bias, zero_wrench); // Clear the stored bias if the argument was false
-    }               
+  return true;
+}
 
-    res.success = true;
-                    
-    return true;    
-  }
-
-  // Calculate the payload's mass and center of mass so gravity can be compensated for, even as the sensor changes orientation.
-  // It's assumed that the payload's center of mass is located on the sensor's central access.
-  // Run this method when the sensor is stationary to avoid inertial effects.
-  // Cannot do gravity compensation if sensor has already been biased.
-  bool NetftUtils::compensateForGravity(netft_interfaces::srv::SetBias::Request &req, netft_interfaces::srv::SetBias::Response &res)
-  {
-
-    if(req.bias)
-    {  
-      if (isBiased)
-      {
-        RCLCPP_ERROR(get_logger(), "Cannot compensate for gravity if the sensor has already been biased, i.e. useful data was wiped out");
-        res.success = false;
-        return false;  
-      }
-      else  // Cannot compensate for gravity if the sensor has already been biased, i.e. useful data was wiped out 
-      {
-        // Get the weight of the payload. Assumes the world Z axis is up.
-        payloadWeight = raw_data_world.wrench.force.z;
-
-        // Calculate the z-coordinate of the payload's center of mass, in the sensor frame.
-        // It's assumed that the x- and y-coordinates are zero.
-        // This is a lever arm.
-        payloadLeverArm = raw_data_tool.wrench.torque.y/raw_data_tool.wrench.force.x;
-      
-        isNewGravityBias = true;
-        isGravityBiased = true;
-      }
-    }
-    
-    res.success = true;     
-    return true;
-  }  
-
-  bool NetftUtils::setFilter(netft_interfaces::srv::SetFilter::Request &req, netft_interfaces::srv::SetFilter::Response &res)
-  {                 
-    if(req.filter)  
+// Calculate the payload's mass and center of mass so gravity can be compensated for, even as the sensor changes orientation.
+// It's assumed that the payload's center of mass is located on the sensor's central access.
+// Run this method when the sensor is stationary to avoid inertial effects.
+// Cannot do gravity compensation if sensor has already been biased.
+bool NetftUtils::compensateForGravity(
+  netft_interfaces::srv::SetBias::Request & req, netft_interfaces::srv::SetBias::Response & res)
+{
+  if (req.bias) {
+    if (isBiased) {
+      RCLCPP_ERROR(
+        get_logger(),
+        "Cannot compensate for gravity if the sensor has already been biased, i.e. useful data was "
+        "wiped out");
+      res.success = false;
+      return false;
+    } else  // Cannot compensate for gravity if the sensor has already been biased, i.e. useful data was wiped out
     {
-      newFilter = true;
-      isFilterOn = true;
-      deltaTFilter = req.t;
-      cutoffFrequency = req.cutoff_frequency;
-    }               
-    else            
-    {               
-      isFilterOn = false;
-    }               
-    
-    return true;    
-  }  
+      // Get the weight of the payload. Assumes the world Z axis is up.
+      payloadWeight = raw_data_world.wrench.force.z;
 
-  bool NetftUtils::setMax(netft_interfaces::srv::SetMax::Request &req, netft_interfaces::srv::SetMax::Response &res)
-  {                 
+      // Calculate the z-coordinate of the payload's center of mass, in the sensor frame.
+      // It's assumed that the x- and y-coordinates are zero.
+      // This is a lever arm.
+      payloadLeverArm = raw_data_tool.wrench.torque.y / raw_data_tool.wrench.force.x;
 
-    if(req.force >= 0.0001)
-      forceMaxU = req.force;
-    if(req.torque >= 0.0001)
-      torqueMaxU = req.torque;
-    
-    res.success = true;             
-    return true;    
+      isNewGravityBias = true;
+      isGravityBiased = true;
+    }
   }
 
-  bool NetftUtils::setWeightBias(netft_interfaces::srv::SetBias::Request &req, netft_interfaces::srv::SetBias::Response &res)
-  {                 
-    if(req.bias)  
-    {               
-      copyWrench(raw_data_tool, weight_bias, zero_wrench);
-    }               
-    else            
-    {               
-      copyWrench(zero_wrench, weight_bias, zero_wrench);
-    }               
-    res.success = true;
-                    
-    return true;    
-  }  
-      
-  bool NetftUtils::getWeight(netft_interfaces::srv::GetDouble::Request &req, netft_interfaces::srv::GetDouble::Response &res)
-  {                 
-    geometry_msgs::msg::WrenchStamped carried_weight;
-    copyWrench(raw_data_tool, carried_weight, weight_bias);
-    res.weight = pow((pow(carried_weight.wrench.force.x, 2.0) + pow(carried_weight.wrench.force.y, 2.0) + pow(carried_weight.wrench.force.z, 2.0)), 0.5)/9.81*1000;
-                    
-    return true;    
-  }      
-              
-  bool NetftUtils::setThreshold(netft_interfaces::srv::SetThreshold::Request &req, netft_interfaces::srv::SetThreshold::Response &res)
-  {                 
-    threshold.wrench.force.x = req.data.wrench.force.x;
-    threshold.wrench.force.y = req.data.wrench.force.y;
-    threshold.wrench.force.z = req.data.wrench.force.z;
-    threshold.wrench.torque.x = req.data.wrench.torque.x;
-    threshold.wrench.torque.y = req.data.wrench.torque.y;
-    threshold.wrench.torque.z = req.data.wrench.torque.z;
-                    
-    res.success = true;
-                    
-    return true;    
+  res.success = true;
+  return true;
+}
+
+bool NetftUtils::setFilter(
+  netft_interfaces::srv::SetFilter::Request & req, netft_interfaces::srv::SetFilter::Response & res)
+{
+  if (req.filter) {
+    newFilter = true;
+    isFilterOn = true;
+    deltaTFilter = req.t;
+    cutoffFrequency = req.cutoff_frequency;
+  } else {
+    isFilterOn = false;
   }
 
-  /**
+  return true;
+}
+
+bool NetftUtils::setMax(
+  netft_interfaces::srv::SetMax::Request & req, netft_interfaces::srv::SetMax::Response & res)
+{
+  if (req.force >= 0.0001) forceMaxU = req.force;
+  if (req.torque >= 0.0001) torqueMaxU = req.torque;
+
+  res.success = true;
+  return true;
+}
+
+bool NetftUtils::setWeightBias(
+  netft_interfaces::srv::SetBias::Request & req, netft_interfaces::srv::SetBias::Response & res)
+{
+  if (req.bias) {
+    copyWrench(raw_data_tool, weight_bias, zero_wrench);
+  } else {
+    copyWrench(zero_wrench, weight_bias, zero_wrench);
+  }
+  res.success = true;
+
+  return true;
+}
+
+bool NetftUtils::getWeight(
+  netft_interfaces::srv::GetDouble::Request & req, netft_interfaces::srv::GetDouble::Response & res)
+{
+  geometry_msgs::msg::WrenchStamped carried_weight;
+  copyWrench(raw_data_tool, carried_weight, weight_bias);
+  res.weight =
+    pow(
+      (pow(carried_weight.wrench.force.x, 2.0) + pow(carried_weight.wrench.force.y, 2.0) +
+       pow(carried_weight.wrench.force.z, 2.0)),
+      0.5) /
+    9.81 * 1000;
+
+  return true;
+}
+
+bool NetftUtils::setThreshold(
+  netft_interfaces::srv::SetThreshold::Request & req,
+  netft_interfaces::srv::SetThreshold::Response & res)
+{
+  threshold.wrench.force.x = req.data.wrench.force.x;
+  threshold.wrench.force.y = req.data.wrench.force.y;
+  threshold.wrench.force.z = req.data.wrench.force.z;
+  threshold.wrench.torque.x = req.data.wrench.torque.x;
+  threshold.wrench.torque.y = req.data.wrench.torque.y;
+  threshold.wrench.torque.z = req.data.wrench.torque.z;
+
+  res.success = true;
+
+  return true;
+}
+
+/**
    * @brief Monitors force and torque magnitudes and manages cancel signaling if limits are exceeded.
    *
    * Computes the magnitudes of force and torque in the tool frame and compares them to configured maximums, which depend on whether biasing is active. If limits are exceeded, sets a cancel message and decrements a counter to limit repeated cancel signals. Implements a wait period after repeated cancels before allowing new cancels. Resets counters when force and torque return to safe levels.
    */
-  void NetftUtils::checkMaxForce()
-  {
-    double fMag = pow((pow(tf_data_tool.wrench.force.x, 2.0) + pow(tf_data_tool.wrench.force.y, 2.0) + pow(tf_data_tool.wrench.force.z, 2.0)), 0.5);
-    double tMag = pow((pow(tf_data_tool.wrench.torque.x, 2.0) + pow(tf_data_tool.wrench.torque.y, 2.0) + pow(tf_data_tool.wrench.torque.z, 2.0)), 0.5);
-    double fMax;
-    double tMax;
-    if(isBiased && !isNewBias)
-    {
-      fMax = forceMaxB;
-      tMax = torqueMaxB;
-    }
-    else
-    {
-      if(isBiased && isNewBias)
-      {
-        isNewBias = false;
-      }
-
-      fMax = forceMaxU; //50.0;
-      tMax = torqueMaxU; //5.0;
+void NetftUtils::checkMaxForce()
+{
+  double fMag = pow(
+    (pow(tf_data_tool.wrench.force.x, 2.0) + pow(tf_data_tool.wrench.force.y, 2.0) +
+     pow(tf_data_tool.wrench.force.z, 2.0)),
+    0.5);
+  double tMag = pow(
+    (pow(tf_data_tool.wrench.torque.x, 2.0) + pow(tf_data_tool.wrench.torque.y, 2.0) +
+     pow(tf_data_tool.wrench.torque.z, 2.0)),
+    0.5);
+  double fMax;
+  double tMax;
+  if (isBiased && !isNewBias) {
+    fMax = forceMaxB;
+    tMax = torqueMaxB;
+  } else {
+    if (isBiased && isNewBias) {
+      isNewBias = false;
     }
 
-    // If max FT exceeded, send cancel unless we have just sent it MAX_CANCEL times
-    //ROS_INFO("FMAG: %f TMAG: %f", fMag, tMag);
-    if((fabs(fMag) > fMax || fabs(tMag) > tMax) && cancel_count > 0)
-    {
-      cancel_msg.cancel = true;
-      //ROS_INFO("Force torque violation. Canceling move.");
-      RCLCPP_INFO(get_logger(), "FMAG: %f FMAX: %f TMAG:%f TMAX: %f count: %d wait: %d", fMag, fMax, tMag, tMax, cancel_count, cancel_wait);
-      cancel_count-=1;
-    }
-    // If we have sent cancel MAX_CANCEL times, don't send cancel again for MAX_WAIT cycles
-    else if(cancel_count == 0 && cancel_wait > 0 && cancel_wait <= MAX_WAIT)
-    {
-      cancel_msg.cancel = false;
-      cancel_wait-=1;
-    }
-    // If we have just finished waiting MAX_WAIT times, or the max force is no longer exceeded, reset cancel_count and cancel_wait
-    else if(cancel_wait == 0 || !(fabs(fMag) > fMax || fabs(tMag) > tMax))
-    {
-      cancel_msg.cancel = false;
-      cancel_count = MAX_CANCEL;
-      cancel_wait = MAX_WAIT;
-    }
-  }               
+    fMax = forceMaxU;   //50.0;
+    tMax = torqueMaxU;  //5.0;
+  }
+
+  // If max FT exceeded, send cancel unless we have just sent it MAX_CANCEL times
+  //ROS_INFO("FMAG: %f TMAG: %f", fMag, tMag);
+  if ((fabs(fMag) > fMax || fabs(tMag) > tMax) && cancel_count > 0) {
+    cancel_msg.cancel = true;
+    //ROS_INFO("Force torque violation. Canceling move.");
+    RCLCPP_INFO(
+      get_logger(), "FMAG: %f FMAX: %f TMAG:%f TMAX: %f count: %d wait: %d", fMag, fMax, tMag, tMax,
+      cancel_count, cancel_wait);
+    cancel_count -= 1;
+  }
+  // If we have sent cancel MAX_CANCEL times, don't send cancel again for MAX_WAIT cycles
+  else if (cancel_count == 0 && cancel_wait > 0 && cancel_wait <= MAX_WAIT) {
+    cancel_msg.cancel = false;
+    cancel_wait -= 1;
+  }
+  // If we have just finished waiting MAX_WAIT times, or the max force is no longer exceeded, reset cancel_count and cancel_wait
+  else if (cancel_wait == 0 || !(fabs(fMag) > fMax || fabs(tMag) > tMax)) {
+    cancel_msg.cancel = false;
+    cancel_count = MAX_CANCEL;
+    cancel_wait = MAX_WAIT;
+  }
 }
+}  // namespace netft_utils
 
 /**
  * @brief Entry point for the netft_utils ROS 2 node.
@@ -532,7 +526,7 @@ void NetftUtils::initialize()
  * @param argv Array of command-line argument strings.
  * @return int Exit code (0 for success, nonzero for failure).
  */
-int main(int argc, char **argv)
+int main(int argc, char ** argv)
 {
   // Initialize the ros netft_utils_node
   rclcpp::init(argc, argv);
@@ -549,37 +543,31 @@ int main(int argc, char **argv)
   exec.add_node(utils);
   exec.spin();
 
-
   // Set up user input
   std::string world_frame;
   std::string ft_frame;
   double forceMaxU = 0.0;
   double torqueMaxU = 0.0;
-  if(argc<3)
-  {
-    RCLCPP_FATAL(utils->getLog(), "You must pass in at least the world and ft frame as command line arguments. Argument options are [world frame, ft frame, max force, max torque]");
+  if (argc < 3) {
+    RCLCPP_FATAL(
+      utils->getLog(),
+      "You must pass in at least the world and ft frame as command line arguments. Argument "
+      "options are [world frame, ft frame, max force, max torque]");
     return 1;
-  }
-  else if(argc>=6)
-  {
+  } else if (argc >= 6) {
     RCLCPP_FATAL(utils->getLog(), "Too many arguments for netft_utils");
-  }
-  else
-  {
+  } else {
     world_frame = argv[1];
     ft_frame = argv[2];
-    if(argc>=4)
-      forceMaxU = atof(argv[3]);
-    if(5==argc)
-      torqueMaxU = atof(argv[4]);
+    if (argc >= 4) forceMaxU = atof(argv[3]);
+    if (5 == argc) torqueMaxU = atof(argv[4]);
   }
   utils->setUserInput(world_frame, ft_frame, forceMaxU, torqueMaxU);
 
   // Main ros loop
   rclcpp::Rate loop_rate(500);
   //ros::Time last;
-  while(rclcpp::ok())
-  {
+  while (rclcpp::ok()) {
     utils->update();
     loop_rate.sleep();
     //ros::Time curr = ros::Time::now();


### PR DESCRIPTION
Expose services for Force/Torch Sensor ROS2 drive package 

Jira issue: [NXT03-333](https://samxl.atlassian.net/browse/NXT03-333)
## Motivation and Context
While the `ros1` branch of `netft_utils` provides utilities to configure the F/T sensor as services (e.g, `setBias`,`compensateGravity`), however these features are missing in `ros2` branch.  This MR addresses this issue.

## Checklist

- [x] No sensitive data is exposed in the code
- [ ] Code changes are covered by tests


## Additional Notes
Additional reviewers: @aashish-tud 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new utility node executable that can be launched via a command.
  - Added a new shared library for filtering functionality.
- **Documentation**
  - Updated usage instructions in the README to include the new utility node.
- **Refactor**
  - Improved logging consistency and callback binding style.
  - Updated class inheritance for clarity and maintainability.
  - Restructured the main function for better execution flow.
- **Chores**
  - Added a new package dependency to support geometry message conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->